### PR TITLE
Add 2 missing states

### DIFF
--- a/src/sdk/gameserver.rs
+++ b/src/sdk/gameserver.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 /// for more information
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum State {
+    /// The initial of a newly created `GameServer` pod
+    Scheduled,
     /// [Ready](https://agones.dev/site/docs/guides/client-sdks/#ready) to take
     /// player connections
     Ready,
@@ -21,6 +23,8 @@ pub enum State {
     /// means the `GameServer` has active players and should not be deleted or
     /// scaled down
     Allocated,
+    /// Failed to send health check in a timely manner
+    Unhealthy,
     /// [Shutdown](https://agones.dev/site/docs/guides/client-sdks/#shutdown)
     /// marks the `GameServer` as reapable
     Shutdown,
@@ -31,9 +35,11 @@ impl std::str::FromStr for State {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
+            "Scheduled" => Self::Scheduled,
             "Ready" => Self::Ready,
             "Reserved" => Self::Reserved,
             "Allocated" => Self::Allocated,
+            "Unhealthy" => Self::Unhealthy,
             "Shutdown" => Self::Shutdown,
             unknown_state => return Err(Error::UnknownState(unknown_state.to_owned())),
         })

--- a/src/sdk/gameserver.rs
+++ b/src/sdk/gameserver.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 /// for more information
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum State {
-    /// The initial of a newly created `GameServer` pod
+    /// The initial state of a newly created `GameServer` pod. Note this state
+    /// is not sent by the SDK server when used locally.
     Scheduled,
     /// [Ready](https://agones.dev/site/docs/guides/client-sdks/#ready) to take
     /// player connections
@@ -23,7 +24,8 @@ pub enum State {
     /// means the `GameServer` has active players and should not be deleted or
     /// scaled down
     Allocated,
-    /// Failed to send health check in a timely manner
+    /// Failed to send health checks in a timely manner according to the health
+    /// spec assigned to the `GameServer`
     Unhealthy,
     /// [Shutdown](https://agones.dev/site/docs/guides/client-sdks/#shutdown)
     /// marks the `GameServer` as reapable


### PR DESCRIPTION
Going off of the [state diagram](https://agones.dev/site/docs/reference/gameserver/#gameserver-state-diagram) these _should_ be the only missing states, but it's hard to say when it's just a string. For a closed set with only a few possible options. :facepalm: 