### PR TITLE
Bump tonic and prost and start testing against the 1.18.0 version of the agones-sdk-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- [PR#5](https://github.com/EmbarkStudios/rymder/pull/5) bump tonic to `0.6` and prost to `0.9`
+
 ## [0.2.2] - 2021-09-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-stream = "0.3"
 chrono = "0.4"
 futures-util = "0.3"
 http = "0.2"
-prost = "0.8"
+prost = "0.9"
 
 [dependencies.tokio]
 version = "1.0"
@@ -30,7 +30,7 @@ default-features = false
 features = ["sync", "time"]
 
 [dependencies.tonic]
-version = "0.5"
+version = "0.6"
 default-features = false
 features = [
     "codegen",

--- a/download-sdk-server.sh
+++ b/download-sdk-server.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+if [ -z "$1" ] 
+  then
+    echo "Platform not supplied, expected either of linux, darwin or windows"
+    exit 1
+fi
+
 which=$1
-agones_version="1.16.0"
+agones_version="1.18.0"
 
 # unzip doesn't support stdin streams so we need to use a temp file
 server_zip=$(mktemp)

--- a/update/Cargo.toml
+++ b/update/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 zip = "0.5"
-tonic-build = { version = "0.5", default-features = false, features = ["prost", "rustfmt", "transport"] }
+tonic-build = { version = "0.6", default-features = false, features = ["prost", "rustfmt", "transport"] }

--- a/update/src/main.rs
+++ b/update/src/main.rs
@@ -3,7 +3,7 @@ fn main() {
         .nth(1)
         .expect("version argument not specified");
 
-    let version = version.strip_prefix("v").unwrap_or(&version);
+    let version = version.strip_prefix('v').unwrap_or(&version);
 
     let zip = reqwest::blocking::get(format!(
         "https://github.com/googleforgames/agones/archive/refs/tags/v{}.zip",


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Bump tonic and prost. Run the test against the 1.18 agones sdk server instead. Also fixed a small clippy lint.

### Related Issues

List related issues here
