### PR TITLE
Allow duplicate `itoa` dependency

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ deny = [
     { name = "openssl-sys" },
 ]
 skip = [
+    { name = "itoa", version = "=0.4.8" },
 ]
 
 [sources]


### PR DESCRIPTION
`http` pulls in version 1.0.1 and hyper pulls version 0.4.8. hyper has
been updated on `master` so after the next release we can remove this.

I'll fix the 0.3.0 release when this is merged.